### PR TITLE
[codex] Add searchable repo picker for flow create

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@inquirer/checkbox": "^5.0.4",
         "@inquirer/confirm": "^6.0.4",
+        "@inquirer/core": "^11.1.1",
         "@inquirer/input": "^5.0.4",
         "chalk": "^5.6.2",
         "commander": "^14.0.3",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   "dependencies": {
     "@inquirer/checkbox": "^5.0.4",
     "@inquirer/confirm": "^6.0.4",
+    "@inquirer/core": "^11.1.1",
     "@inquirer/input": "^5.0.4",
     "chalk": "^5.6.2",
     "commander": "^14.0.3",

--- a/src/commands/__test__/repoPicker.test.ts
+++ b/src/commands/__test__/repoPicker.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest';
+import {
+  filterRepoPickerChoices,
+  getNextSelectableRepoValue,
+  getSelectedRepoPickerValues,
+  normalizeRepoPickerChoices,
+  toggleRepoPickerChoice,
+} from '../repoPicker.js';
+
+describe('repoPicker', () => {
+  it('filters repos case-insensitively by name and ignores separators', () => {
+    const items = normalizeRepoPickerChoices([
+      { separator: 'Recently Used' },
+      { name: 'payments-api', value: '/source/payments-api', checked: false },
+      { name: 'worker', value: '/source/worker', checked: false },
+      { separator: '' },
+      { name: 'API-gateway', value: '/source/api-gateway', checked: true },
+    ]);
+
+    const filtered = filterRepoPickerChoices(items, 'api');
+
+    expect(filtered.map((item) => item.name)).toEqual(['payments-api', 'API-gateway']);
+  });
+
+  it('preserves checked repos when toggling while filtered and then clearing the search', () => {
+    const items = normalizeRepoPickerChoices([
+      { separator: 'Recently Used' },
+      { name: 'repo-one', value: '/source/repo-one', checked: false },
+      { name: 'repo-two', value: '/source/repo-two', checked: true },
+      { separator: '' },
+      { name: 'repo-three', value: '/source/repo-three', checked: false },
+    ]);
+
+    const filtered = filterRepoPickerChoices(items, 'repo-one');
+    const toggled = toggleRepoPickerChoice(items, filtered[0]?.value);
+
+    expect(getSelectedRepoPickerValues(toggled)).toEqual([
+      '/source/repo-one',
+      '/source/repo-two',
+    ]);
+
+    const restored = filterRepoPickerChoices(toggled, '');
+    expect(restored.find((item) => item.name === 'repo-one')?.checked).toBe(true);
+    expect(restored.find((item) => item.name === 'repo-two')?.checked).toBe(true);
+    expect(restored.find((item) => item.name === 'repo-three')?.checked).toBe(false);
+  });
+
+  it('moves through selectable repos without landing on separators', () => {
+    const items = normalizeRepoPickerChoices([
+      { separator: 'Recently Used' },
+      { name: 'repo-one', value: '/source/repo-one', checked: false },
+      { separator: '' },
+      { name: 'repo-two', value: '/source/repo-two', checked: false },
+      { name: 'repo-three', value: '/source/repo-three', checked: false },
+    ]);
+
+    expect(getNextSelectableRepoValue(items, '/source/repo-one', 1, false)).toBe('/source/repo-two');
+    expect(getNextSelectableRepoValue(items, '/source/repo-three', 1, false)).toBe('/source/repo-three');
+    expect(getNextSelectableRepoValue(items, '/source/repo-one', -1, true)).toBe('/source/repo-three');
+  });
+
+  it('returns no matches when the search query misses every repo', () => {
+    const items = normalizeRepoPickerChoices([
+      { name: 'frontend', value: '/source/frontend', checked: false },
+      { name: 'backend', value: '/source/backend', checked: false },
+    ]);
+
+    expect(filterRepoPickerChoices(items, 'mobile')).toEqual([]);
+  });
+});

--- a/src/commands/__test__/repoPicker.test.ts
+++ b/src/commands/__test__/repoPicker.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import {
   filterRepoPickerChoices,
   getTypedCharacter,
+  isEscapeKey,
   getNextSelectableRepoValue,
   getSelectedRepoPickerValues,
   normalizeRepoPickerChoices,
@@ -74,5 +75,10 @@ describe('repoPicker', () => {
     expect(getTypedCharacter({ sequence: 'a', ctrl: false, meta: false })).toBe('a');
     expect(getTypedCharacter({ sequence: '\r', ctrl: false, meta: false })).toBe('\r');
     expect(getTypedCharacter({ sequence: 'a', ctrl: true, meta: false })).toBeUndefined();
+  });
+
+  it('recognizes escape as the key used to exit search mode', () => {
+    expect(isEscapeKey({ name: 'escape' })).toBe(true);
+    expect(isEscapeKey({ name: 'enter' })).toBe(false);
   });
 });

--- a/src/commands/__test__/repoPicker.test.ts
+++ b/src/commands/__test__/repoPicker.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import {
   filterRepoPickerChoices,
+  getTypedCharacter,
   getNextSelectableRepoValue,
   getSelectedRepoPickerValues,
   normalizeRepoPickerChoices,
@@ -66,5 +67,12 @@ describe('repoPicker', () => {
     ]);
 
     expect(filterRepoPickerChoices(items, 'mobile')).toEqual([]);
+  });
+
+  it('treats punctuation sequences like slash as typed characters for search mode', () => {
+    expect(getTypedCharacter({ sequence: '/', ctrl: false, meta: false })).toBe('/');
+    expect(getTypedCharacter({ sequence: 'a', ctrl: false, meta: false })).toBe('a');
+    expect(getTypedCharacter({ sequence: '\r', ctrl: false, meta: false })).toBe('\r');
+    expect(getTypedCharacter({ sequence: 'a', ctrl: true, meta: false })).toBeUndefined();
   });
 });

--- a/src/commands/create.ts
+++ b/src/commands/create.ts
@@ -1,6 +1,5 @@
 import path from 'node:path';
 import { Command } from 'commander';
-import checkbox, { Separator } from '@inquirer/checkbox';
 import input from '@inquirer/input';
 import confirm from '@inquirer/confirm';
 import chalk from 'chalk';
@@ -10,6 +9,10 @@ import type { Services } from '../lib/services.js';
 import type { UseCases } from '../usecases/usecases.js';
 import { NoReposFoundError } from '../lib/errors.js';
 import { buildRepoCheckboxChoices } from './helpers.js';
+import {
+  searchableRepoCheckbox,
+  type RepoPickerSeparator,
+} from './repoPicker.js';
 
 export async function runCreate(
   branchName: string,
@@ -30,7 +33,12 @@ export async function runCreate(
   }
 
   // User prompts
-  const checkboxChoices = buildRepoCheckboxChoices(repos, services, config.branchAutoSelectRepos, (label) => new Separator(label));
+  const checkboxChoices = buildRepoCheckboxChoices(
+    repos,
+    services,
+    config.branchAutoSelectRepos,
+    (label): RepoPickerSeparator => ({ separator: label ?? '' })
+  );
 
   const selected = await deps.checkbox({
     message: `Select repos for branch "${branchName}":`,
@@ -157,7 +165,7 @@ export function registerCreateCommand(program: Command): void {
       const useCases = createUseCases(services);
 
       try {
-        await runCreate(branchName, useCases, services, { checkbox, input, confirm });
+        await runCreate(branchName, useCases, services, { checkbox: searchableRepoCheckbox, input, confirm });
       } catch (error: any) {
         services.console.error(error.message);
         services.process.exit(1);

--- a/src/commands/helpers.ts
+++ b/src/commands/helpers.ts
@@ -14,6 +14,12 @@ type WorkspaceStatusInfo = {
   statuses: Array<{ repoName: string; status: WorktreeStatus }>;
 };
 
+export type RepoCheckboxChoice = {
+  name: string;
+  value: string;
+  checked: boolean;
+};
+
 /**
  * Format a single repo's status as a display line, consistent across list and status commands.
  */
@@ -79,12 +85,12 @@ export function logStatus(
  *
  * @param createSeparator - factory from the display layer (e.g. inquirer's Separator constructor)
  */
-export function buildRepoCheckboxChoices(
+export function buildRepoCheckboxChoices<TSeparator>(
   repos: string[],
   services: Pick<Services, 'repos' | 'fetchCache'>,
   preSelected: string[],
-  createSeparator: (label?: string) => unknown
-): unknown[] {
+  createSeparator: (label?: string) => TSeparator
+): Array<RepoCheckboxChoice | TSeparator> {
   const choices = services.repos.formatRepoChoices(repos).map((choice) => ({
     ...choice,
     checked: preSelected.includes(choice.name),
@@ -105,4 +111,3 @@ export function buildRepoCheckboxChoices(
 
   return choices;
 }
-

--- a/src/commands/repoPicker.ts
+++ b/src/commands/repoPicker.ts
@@ -58,6 +58,8 @@ type SearchableRepoPickerConfig = {
   loop?: boolean;
 };
 
+const HIDE_CURSOR = '\x1B[?25l';
+
 type RepoPickerKeypress = {
   name?: string;
   sequence?: string;
@@ -342,5 +344,5 @@ export const searchableRepoCheckbox = createPrompt<string[], SearchableRepoPicke
     .join('\n')
     .trimEnd();
 
-  return lines;
+  return `${lines}${HIDE_CURSOR}`;
 });

--- a/src/commands/repoPicker.ts
+++ b/src/commands/repoPicker.ts
@@ -1,7 +1,6 @@
 import chalk from 'chalk';
 import {
   ValidationError,
-  createPrompt,
   isBackspaceKey,
   isDownKey,
   isEnterKey,
@@ -14,6 +13,7 @@ import {
   type Status,
 } from '@inquirer/core';
 import type { RepoCheckboxChoice } from './helpers.js';
+import { createPromptWithEscapeCodeTimeout } from '../lib/createPromptWithEscapeCodeTimeout.js';
 
 export type RepoPickerSeparator = {
   separator?: string;
@@ -59,6 +59,7 @@ type SearchableRepoPickerConfig = {
 };
 
 const HIDE_CURSOR = '\x1B[?25l';
+const ESCAPE_CODE_TIMEOUT_MS = 25;
 
 type RepoPickerKeypress = {
   name?: string;
@@ -188,6 +189,10 @@ export function getTypedCharacter(key: RepoPickerKeypress): string | undefined {
   return key.sequence;
 }
 
+export function isEscapeKey(key: RepoPickerKeypress): boolean {
+  return key.name === 'escape';
+}
+
 function getSelectionSummary(items: ReadonlyArray<NormalizedRepoPickerItem>): string {
   const selectedChoices = items.filter(
     (item): item is NormalizedRepoPickerChoice => isRepoPickerChoice(item) && item.checked
@@ -204,7 +209,7 @@ function getNoMatchesMessage(query: string): string {
   return `No matching repos for "${query}".`;
 }
 
-export const searchableRepoCheckbox = createPrompt<string[], SearchableRepoPickerConfig>((config, done) => {
+export const searchableRepoCheckbox = createPromptWithEscapeCodeTimeout<string[], SearchableRepoPickerConfig>((config, done) => {
   const { loop = true, pageSize = 7 } = config;
   const initialItems = normalizeRepoPickerChoices(config.choices);
 
@@ -242,13 +247,13 @@ export const searchableRepoCheckbox = createPrompt<string[], SearchableRepoPicke
 
     readline.clearLine(0);
 
-    if (isEnterKey(key)) {
-      if (searchMode) {
-        setSearchMode(false);
-        setQuery('');
-        return;
-      }
+    if (searchMode && isEscapeKey(typedKey)) {
+      setSearchMode(false);
+      setQuery('');
+      return;
+    }
 
+    if (isEnterKey(key)) {
       setStatus('done');
       done(getSelectedRepoPickerValues(items));
       return;
@@ -330,7 +335,7 @@ export const searchableRepoCheckbox = createPrompt<string[], SearchableRepoPicke
     : `${prefix} ${chalk.bold(config.message)}`;
 
   const help = searchMode
-    ? chalk.dim('up/down navigate | space select | type filter | enter clear search')
+    ? chalk.dim('up/down navigate | space select | type filter | esc clear search | enter continue')
     : chalk.dim('up/down navigate | space select | / search | enter continue');
 
   const lines = [
@@ -345,4 +350,4 @@ export const searchableRepoCheckbox = createPrompt<string[], SearchableRepoPicke
     .trimEnd();
 
   return `${lines}${HIDE_CURSOR}`;
-});
+}, ESCAPE_CODE_TIMEOUT_MS);

--- a/src/commands/repoPicker.ts
+++ b/src/commands/repoPicker.ts
@@ -1,0 +1,337 @@
+import chalk from 'chalk';
+import {
+  ValidationError,
+  createPrompt,
+  isBackspaceKey,
+  isDownKey,
+  isEnterKey,
+  isSpaceKey,
+  isUpKey,
+  useKeypress,
+  usePagination,
+  usePrefix,
+  useState,
+  type Status,
+} from '@inquirer/core';
+import type { RepoCheckboxChoice } from './helpers.js';
+
+export type RepoPickerSeparator = {
+  separator?: string;
+};
+
+export type RepoPickerChoice = RepoCheckboxChoice & {
+  description?: string;
+  disabled?: boolean | string;
+  short?: string;
+};
+
+export type RepoPickerItem = RepoPickerChoice | RepoPickerSeparator;
+
+export type NormalizedRepoPickerChoice = {
+  type: 'choice';
+  value: string;
+  name: string;
+  checked: boolean;
+  short: string;
+  description?: string;
+  disabled: boolean | string;
+};
+
+export type NormalizedRepoPickerSeparator = {
+  type: 'separator';
+  separator: string;
+};
+
+type NormalizedRepoPickerItem = NormalizedRepoPickerChoice | NormalizedRepoPickerSeparator;
+
+type RepoPickerEmptyState = {
+  type: 'empty';
+  message: string;
+};
+
+type RepoPickerRenderItem = NormalizedRepoPickerItem | RepoPickerEmptyState;
+
+type SearchableRepoPickerConfig = {
+  message: string;
+  choices: ReadonlyArray<RepoPickerItem>;
+  pageSize?: number;
+  loop?: boolean;
+};
+
+function isRepoPickerChoice(item: NormalizedRepoPickerItem | RepoPickerRenderItem): item is NormalizedRepoPickerChoice {
+  return item.type === 'choice';
+}
+
+function isRepoPickerSeparator(item: RepoPickerItem): item is RepoPickerSeparator {
+  return typeof item === 'object' && item !== null && 'separator' in item && !('value' in item);
+}
+
+function isRepoPickerEmptyState(item: RepoPickerRenderItem): item is RepoPickerEmptyState {
+  return item.type === 'empty';
+}
+
+export function normalizeRepoPickerChoices(
+  choices: ReadonlyArray<RepoPickerItem>
+): NormalizedRepoPickerItem[] {
+  return choices.map((choice) => {
+    if (isRepoPickerSeparator(choice)) {
+      return {
+        type: 'separator',
+        separator: choice.separator ?? '',
+      };
+    }
+
+    return {
+      type: 'choice',
+      value: choice.value,
+      name: choice.name,
+      checked: choice.checked,
+      short: choice.short ?? choice.name,
+      description: choice.description,
+      disabled: choice.disabled ?? false,
+    };
+  });
+}
+
+export function filterRepoPickerChoices(
+  items: ReadonlyArray<NormalizedRepoPickerItem>,
+  query: string
+): NormalizedRepoPickerChoice[] {
+  const trimmedQuery = query.trim().toLowerCase();
+  return items.filter((item): item is NormalizedRepoPickerChoice => {
+    if (!isRepoPickerChoice(item)) {
+      return false;
+    }
+
+    if (trimmedQuery.length === 0) {
+      return true;
+    }
+
+    return item.name.toLowerCase().includes(trimmedQuery);
+  });
+}
+
+export function getSelectedRepoPickerValues(
+  items: ReadonlyArray<NormalizedRepoPickerItem>
+): string[] {
+  return items
+    .filter((item): item is NormalizedRepoPickerChoice => isRepoPickerChoice(item) && item.checked)
+    .map((item) => item.value);
+}
+
+export function getFirstSelectableRepoValue(
+  items: ReadonlyArray<NormalizedRepoPickerItem>
+): string | undefined {
+  return items.find(isRepoPickerChoice)?.value;
+}
+
+export function getNextSelectableRepoValue(
+  items: ReadonlyArray<NormalizedRepoPickerItem>,
+  currentValue: string | undefined,
+  direction: -1 | 1,
+  loop: boolean
+): string | undefined {
+  const choices = items.filter(isRepoPickerChoice);
+
+  if (choices.length === 0) {
+    return undefined;
+  }
+
+  const currentIndex = choices.findIndex((choice) => choice.value === currentValue);
+  const startIndex = currentIndex === -1 ? 0 : currentIndex;
+  let nextIndex = startIndex + direction;
+
+  if (loop) {
+    nextIndex = (nextIndex + choices.length) % choices.length;
+  } else {
+    nextIndex = Math.max(0, Math.min(choices.length - 1, nextIndex));
+  }
+
+  return choices[nextIndex]?.value;
+}
+
+export function toggleRepoPickerChoice(
+  items: ReadonlyArray<NormalizedRepoPickerItem>,
+  value: string | undefined
+): NormalizedRepoPickerItem[] {
+  if (!value) {
+    return [...items];
+  }
+
+  return items.map((item) => {
+    if (!isRepoPickerChoice(item) || item.value !== value || item.disabled) {
+      return item;
+    }
+
+    return {
+      ...item,
+      checked: !item.checked,
+    };
+  });
+}
+
+function isPrintableCharacterKey(key: { value?: string; ctrl?: boolean; meta?: boolean }): key is { value: string } {
+  return typeof key.value === 'string' && key.value.length === 1 && !key.ctrl && !key.meta;
+}
+
+function getSelectionSummary(items: ReadonlyArray<NormalizedRepoPickerItem>): string {
+  const selectedChoices = items.filter(
+    (item): item is NormalizedRepoPickerChoice => isRepoPickerChoice(item) && item.checked
+  );
+
+  if (selectedChoices.length === 0) {
+    return chalk.dim('none');
+  }
+
+  return chalk.cyan(selectedChoices.map((item) => item.short).join(', '));
+}
+
+function getNoMatchesMessage(query: string): string {
+  return `No matching repos for "${query}".`;
+}
+
+export const searchableRepoCheckbox = createPrompt<string[], SearchableRepoPickerConfig>((config, done) => {
+  const { loop = true, pageSize = 7 } = config;
+  const initialItems = normalizeRepoPickerChoices(config.choices);
+
+  if (initialItems.every((item) => !isRepoPickerChoice(item))) {
+    throw new ValidationError('[repo picker] No selectable choices.');
+  }
+
+  const [status, setStatus] = useState<Status>('idle');
+  const [items, setItems] = useState<ReadonlyArray<NormalizedRepoPickerItem>>(initialItems);
+  const [searchMode, setSearchMode] = useState(false);
+  const [query, setQuery] = useState('');
+  const [activeValue, setActiveValue] = useState<string | undefined>(
+    getFirstSelectableRepoValue(initialItems)
+  );
+  const prefix = usePrefix({ status });
+
+  const visibleItems = searchMode ? filterRepoPickerChoices(items, query) : items;
+  const visibleChoices = visibleItems.filter(isRepoPickerChoice);
+  const resolvedActiveValue = visibleChoices.some((choice) => choice.value === activeValue)
+    ? activeValue
+    : visibleChoices[0]?.value;
+
+  const renderItems: ReadonlyArray<RepoPickerRenderItem> =
+    searchMode && visibleChoices.length === 0
+      ? [{ type: 'empty', message: getNoMatchesMessage(query) }]
+      : visibleItems;
+
+  const activeRenderIndex = renderItems.findIndex(
+    (item) => isRepoPickerChoice(item) && item.value === resolvedActiveValue
+  );
+
+  useKeypress((key, readline) => {
+    const typedKey = key as typeof key & {
+      value?: string;
+      ctrl?: boolean;
+      meta?: boolean;
+    };
+
+    readline.clearLine(0);
+
+    if (isEnterKey(key)) {
+      if (searchMode) {
+        setSearchMode(false);
+        setQuery('');
+        return;
+      }
+
+      setStatus('done');
+      done(getSelectedRepoPickerValues(items));
+      return;
+    }
+
+    if (isUpKey(key) || isDownKey(key)) {
+      const direction = isUpKey(key) ? -1 : 1;
+      const nextValue = getNextSelectableRepoValue(
+        visibleItems,
+        resolvedActiveValue,
+        direction,
+        loop
+      );
+
+      if (nextValue) {
+        setActiveValue(nextValue);
+      }
+      return;
+    }
+
+    if (isSpaceKey(key)) {
+      setItems(toggleRepoPickerChoice(items, resolvedActiveValue));
+      return;
+    }
+
+    if (!searchMode && typedKey.value === '/') {
+      setSearchMode(true);
+      setQuery('');
+      return;
+    }
+
+    if (!searchMode) {
+      return;
+    }
+
+    if (isBackspaceKey(key)) {
+      setQuery(query.slice(0, -1));
+      return;
+    }
+
+    if (isPrintableCharacterKey(typedKey)) {
+      setQuery(query + typedKey.value);
+    }
+  });
+
+  if (status === 'done') {
+    return `${prefix} ${chalk.bold(config.message)} ${getSelectionSummary(items)}`;
+  }
+
+  let description: string | undefined;
+  const page = usePagination({
+    items: renderItems,
+    active: activeRenderIndex === -1 ? 0 : activeRenderIndex,
+    renderItem({ item, isActive }) {
+      if (isRepoPickerEmptyState(item)) {
+        return chalk.yellow(`  ${item.message}`);
+      }
+
+      if (item.type === 'separator') {
+        return ` ${chalk.dim(item.separator)}`;
+      }
+
+      if (isActive) {
+        description = item.description;
+      }
+
+      const cursor = isActive ? '>' : ' ';
+      const checkbox = item.checked ? '[x]' : '[ ]';
+      const label = item.checked ? chalk.cyan(item.name) : item.name;
+      const activeLabel = isActive ? chalk.bold(label) : label;
+      return `${cursor}${checkbox} ${activeLabel}`;
+    },
+    pageSize,
+    loop,
+  });
+
+  const prompt = searchMode
+    ? `${prefix} ${chalk.bold(config.message)} ${chalk.dim('[search]')} ${chalk.cyan('/')}${query}`
+    : `${prefix} ${chalk.bold(config.message)}`;
+
+  const help = searchMode
+    ? chalk.dim('up/down navigate | space select | type filter | enter clear search')
+    : chalk.dim('up/down navigate | space select | / search | enter continue');
+
+  const lines = [
+    prompt,
+    page,
+    ' ',
+    description ? chalk.cyan(description) : '',
+    help,
+  ]
+    .filter(Boolean)
+    .join('\n')
+    .trimEnd();
+
+  return lines;
+});

--- a/src/commands/repoPicker.ts
+++ b/src/commands/repoPicker.ts
@@ -58,6 +58,14 @@ type SearchableRepoPickerConfig = {
   loop?: boolean;
 };
 
+type RepoPickerKeypress = {
+  name?: string;
+  sequence?: string;
+  ctrl?: boolean;
+  meta?: boolean;
+  shift?: boolean;
+};
+
 function isRepoPickerChoice(item: NormalizedRepoPickerItem | RepoPickerRenderItem): item is NormalizedRepoPickerChoice {
   return item.type === 'choice';
 }
@@ -170,8 +178,12 @@ export function toggleRepoPickerChoice(
   });
 }
 
-function isPrintableCharacterKey(key: { value?: string; ctrl?: boolean; meta?: boolean }): key is { value: string } {
-  return typeof key.value === 'string' && key.value.length === 1 && !key.ctrl && !key.meta;
+export function getTypedCharacter(key: RepoPickerKeypress): string | undefined {
+  if (typeof key.sequence !== 'string' || key.sequence.length !== 1 || key.ctrl || key.meta) {
+    return undefined;
+  }
+
+  return key.sequence;
 }
 
 function getSelectionSummary(items: ReadonlyArray<NormalizedRepoPickerItem>): string {
@@ -223,11 +235,8 @@ export const searchableRepoCheckbox = createPrompt<string[], SearchableRepoPicke
   );
 
   useKeypress((key, readline) => {
-    const typedKey = key as typeof key & {
-      value?: string;
-      ctrl?: boolean;
-      meta?: boolean;
-    };
+    const typedKey = key as typeof key & RepoPickerKeypress;
+    const typedCharacter = getTypedCharacter(typedKey);
 
     readline.clearLine(0);
 
@@ -263,7 +272,7 @@ export const searchableRepoCheckbox = createPrompt<string[], SearchableRepoPicke
       return;
     }
 
-    if (!searchMode && typedKey.value === '/') {
+    if (!searchMode && typedCharacter === '/') {
       setSearchMode(true);
       setQuery('');
       return;
@@ -278,8 +287,8 @@ export const searchableRepoCheckbox = createPrompt<string[], SearchableRepoPicke
       return;
     }
 
-    if (isPrintableCharacterKey(typedKey)) {
-      setQuery(query + typedKey.value);
+    if (typedCharacter) {
+      setQuery(query + typedCharacter);
     }
   });
 

--- a/src/lib/__test__/createPromptWithEscapeCodeTimeout.test.ts
+++ b/src/lib/__test__/createPromptWithEscapeCodeTimeout.test.ts
@@ -1,0 +1,73 @@
+import { EventEmitter } from 'node:events';
+import { PassThrough } from 'node:stream';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const { createInterfaceMock } = vi.hoisted(() => ({
+  createInterfaceMock: vi.fn(),
+}));
+
+vi.mock('node:readline', async () => {
+  const actual = await vi.importActual<typeof import('node:readline')>('node:readline');
+
+  return {
+    ...actual,
+    createInterface: createInterfaceMock,
+  };
+});
+
+import { createPromptWithEscapeCodeTimeout } from '../createPromptWithEscapeCodeTimeout.js';
+
+describe('createPromptWithEscapeCodeTimeout', () => {
+  afterEach(() => {
+    createInterfaceMock.mockReset();
+  });
+
+  it('creates readline with a low escape timeout so standalone esc resolves quickly', async () => {
+    const input = new EventEmitter() as unknown as NodeJS.ReadableStream;
+    const output = new PassThrough();
+    const readlineEvents = new EventEmitter();
+
+    createInterfaceMock.mockImplementation((options: unknown) => {
+        const { input: rlInput, output: rlOutput } = options as {
+          input: NodeJS.ReadableStream;
+          output: NodeJS.WritableStream & {
+            mute: () => void;
+            unmute: () => void;
+            write: (chunk: string) => boolean;
+          };
+        };
+
+        return {
+          input: rlInput,
+          output: rlOutput,
+          line: '',
+          getCursorPos: () => ({ rows: 0, cols: 0 }),
+          setPrompt: vi.fn(),
+          clearLine: vi.fn(),
+          on: readlineEvents.on.bind(readlineEvents),
+          removeListener: readlineEvents.removeListener.bind(readlineEvents),
+          close: () => {
+            readlineEvents.emit('close');
+          },
+        } as any;
+      });
+
+    const prompt = createPromptWithEscapeCodeTimeout<string, { message: string }>(
+      (config, done) => {
+        done(config.message);
+        return `? ${config.message}`;
+      },
+      25
+    );
+
+    await expect(prompt({ message: 'ok' }, { input, output })).resolves.toBe('ok');
+
+    expect(createInterfaceMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        terminal: true,
+        input,
+        escapeCodeTimeout: 25,
+      })
+    );
+  });
+});

--- a/src/lib/createPromptWithEscapeCodeTimeout.ts
+++ b/src/lib/createPromptWithEscapeCodeTimeout.ts
@@ -1,0 +1,121 @@
+import * as readline from 'node:readline';
+import { AsyncResource } from 'node:async_hooks';
+import MuteStream from 'mute-stream';
+import { onExit as onSignalExit } from 'signal-exit';
+import type { InquirerReadline } from '@inquirer/type';
+import ScreenManager from '../../node_modules/@inquirer/core/dist/lib/screen-manager.js';
+import { PromisePolyfill } from '../../node_modules/@inquirer/core/dist/lib/promise-polyfill.js';
+import { withHooks, effectScheduler } from '../../node_modules/@inquirer/core/dist/lib/hook-engine.js';
+import {
+  AbortPromptError,
+  CancelPromptError,
+  ExitPromptError,
+} from '../../node_modules/@inquirer/core/dist/lib/errors.js';
+
+type PromptContext = {
+  input?: NodeJS.ReadableStream;
+  output?: NodeJS.WritableStream;
+  signal?: AbortSignal;
+  clearPromptOnDone?: boolean;
+};
+
+type PromptReturnValue = string | [string, string?];
+
+export function createPromptWithEscapeCodeTimeout<Value, Config>(
+  view: (config: Config, done: (value: Value) => void) => PromptReturnValue,
+  escapeCodeTimeout: number
+): (config: Config, context?: PromptContext) => Promise<Value> & { cancel: () => void } {
+  return (config: Config, context: PromptContext = {}) => {
+    const { input = process.stdin, signal } = context;
+    const cleanups = new Set<() => void>();
+
+    const output = new MuteStream() as unknown as NodeJS.WritableStream & {
+      pipe(destination: NodeJS.WritableStream): NodeJS.WritableStream;
+      end(): void;
+    };
+    output.pipe(context.output ?? process.stdout);
+
+    const rl = readline.createInterface(
+      {
+        terminal: true,
+        input: input as NodeJS.ReadableStream,
+        output: output as NodeJS.WritableStream,
+        escapeCodeTimeout,
+      } as readline.ReadLineOptions
+    ) as unknown as InquirerReadline;
+
+    const screen = new ScreenManager(rl);
+    const { promise, resolve, reject } = PromisePolyfill.withResolver<Value>();
+    const cancel = () => reject(new CancelPromptError());
+
+    if (signal) {
+      const abort = () => reject(new AbortPromptError({ cause: signal.reason }));
+      if (signal.aborted) {
+        abort();
+        return Object.assign(promise, { cancel });
+      }
+
+      signal.addEventListener('abort', abort);
+      cleanups.add(() => signal.removeEventListener('abort', abort));
+    }
+
+    cleanups.add(
+      onSignalExit((code, receivedSignal) => {
+        reject(new ExitPromptError(`User force closed the prompt with ${code} ${receivedSignal}`));
+      })
+    );
+
+    const sigint = () => reject(new ExitPromptError('User force closed the prompt with SIGINT'));
+    rl.on('SIGINT', sigint);
+    cleanups.add(() => rl.removeListener('SIGINT', sigint));
+
+    const checkCursorPos = () => screen.checkCursorPos();
+    rl.input.on('keypress', checkCursorPos);
+    cleanups.add(() => rl.input.removeListener('keypress', checkCursorPos));
+
+    return withHooks(rl, (cycle) => {
+      const hooksCleanup = AsyncResource.bind(() => effectScheduler.clearAll());
+      rl.on('close', hooksCleanup);
+      cleanups.add(() => rl.removeListener('close', hooksCleanup));
+
+      cycle(() => {
+        try {
+          const nextView = view(config, (value) => {
+            setImmediate(() => resolve(value));
+          });
+
+          if (nextView === undefined) {
+            throw new Error('Prompt functions must return a string.');
+          }
+
+          const [content, bottomContent] = typeof nextView === 'string' ? [nextView] : nextView;
+          screen.render(content, bottomContent);
+          effectScheduler.run();
+        } catch (error) {
+          reject(error);
+        }
+      });
+
+      return Object.assign(
+        promise
+          .then(
+            (answer) => {
+              effectScheduler.clearAll();
+              return answer;
+            },
+            (error) => {
+              effectScheduler.clearAll();
+              throw error;
+            }
+          )
+          .finally(() => {
+            cleanups.forEach((cleanup) => cleanup());
+            screen.done({ clearContent: Boolean(context.clearPromptOnDone) });
+            output.end();
+          })
+          .then(() => promise),
+        { cancel }
+      );
+    });
+  };
+}

--- a/src/types/mute-stream.d.ts
+++ b/src/types/mute-stream.d.ts
@@ -1,0 +1,6 @@
+declare module 'mute-stream' {
+  export default class MuteStream {
+    pipe(destination: NodeJS.WritableStream): NodeJS.WritableStream;
+    end(): void;
+  }
+}


### PR DESCRIPTION
## Summary

This PR adds a searchable repo picker to `flow create` so repo selection stays usable in larger source trees.

## Demo:
![flow-create-search-demo](https://github.com/user-attachments/assets/222594f8-4b6d-4f0d-94de-f223534395d8)


## What Changed

- added a custom repo picker for `flow create` that supports `/` to enter filter mode
- made repo filtering case-insensitive on repo name while preserving checked selections across searches
- changed search exit behavior so `Esc` clears and exits search while `Enter` continues the overall selection flow
- hid the trailing terminal cursor during the custom picker render
- reduced standalone `Esc` latency by constructing the prompt with a low readline `escapeCodeTimeout`
- added regression coverage for repo picker behavior and the escape-timeout prompt configuration

## Why

Issue #5 called out that the existing static checkbox list becomes slow and error-prone once there are dozens of repos. The initial custom prompt work also exposed a few follow-up UX issues around `/`, `Esc`, cursor rendering, and escape-key responsiveness that are included here.

## User Impact

- `flow create <branch>` now supports `/` search in the repo picker
- selections remain checked while moving in and out of filtered views
- no-match searches show a clear message instead of failing silently
- `Esc` exits search mode quickly without the previous half-second delay

## Root Cause

The stock `@inquirer/checkbox` prompt does not provide the slash-search flow required for this picker. After introducing a custom prompt, standalone `Esc` still felt laggy because Node readline only honors `escapeCodeTimeout` when the interface is created, not when the property is mutated afterward.

## Validation

- `npm run validate`
- `npm test -- --run src/lib/__test__/createPromptWithEscapeCodeTimeout.test.ts src/commands/__test__/repoPicker.test.ts src/commands/__integration__/create.integration.test.ts`

Closes #5.
